### PR TITLE
Fix usage of page converter

### DIFF
--- a/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
@@ -231,14 +231,12 @@ public class CalciteFilterPlugin
         // Set input schema in PageSchema for various types of executor plugins
         PageSchema.schema = inputSchema;
 
-        // Set page converter as TLS variable in PageTable
-        PageTable.pageConverter.set(newPageConverter(task, inputSchema));
-
         PageBuilder pageBuilder = new PageBuilder(task.getBufferAllocator(), outputSchema, output);
+        PageConverter pageConverter = newPageConverter(task, inputSchema);
         ColumnGetterFactory factory = newColumnGetterFactory(task, Optional.of(pageBuilder));
         List<ColumnGetter> getters = newColumnGetters(factory, task.getQuerySchema());
         Properties props = System.getProperties(); // TODO should be configured as config option
-        return new FilterPageOutput(outputSchema, task.getQuery(), pageBuilder, getters, props);
+        return new FilterPageOutput(outputSchema, task.getQuery(), pageBuilder, pageConverter, getters, props);
     }
 
     private class FilterPageOutput
@@ -247,14 +245,17 @@ public class CalciteFilterPlugin
         private final Schema outputSchema;
         private final String query;
         private final PageBuilder pageBuilder;
+        private final PageConverter pageConverter;
         private final List<ColumnGetter> getters;
         private final Properties props;
 
-        private FilterPageOutput(Schema outputSchema, String query, PageBuilder pageBuilder, List<ColumnGetter> getters, Properties props)
+        private FilterPageOutput(Schema outputSchema, String query, PageBuilder pageBuilder, PageConverter pageConverter,
+                List<ColumnGetter> getters, Properties props)
         {
             this.outputSchema = outputSchema;
             this.query = query;
             this.pageBuilder = pageBuilder;
+            this.pageConverter = pageConverter;
             this.getters = getters;
             this.props = props;
         }
@@ -262,6 +263,9 @@ public class CalciteFilterPlugin
         @Override
         public void add(Page page)
         {
+            // Set page converter as TLS variable in PageTable
+            PageTable.pageConverter.set(pageConverter);
+
             // Set page as TLS variable in PageTable
             PageTable.page.set(page);
 
@@ -281,6 +285,7 @@ public class CalciteFilterPlugin
                 throw Throwables.propagate(e); // TODO better exception handling? error messages?
             }
             finally {
+                PageTable.pageConverter.remove();
                 PageTable.page.remove();
             }
         }


### PR DESCRIPTION
@dmikurube I noticed that I made bugs related to the usage of PageConverter objects.

* PageConverter obejcts are used in FilterPageOutput#add and it is not same thread as one that creates FilterPageOutput objects. So, I need to insert PageConverter objects at the begin of the add method. 
* In transaction method, PageConverter object is inserted but, not removed. I added the removing code.

The part of the stacktrace here.
```
... ...
Caused by: org.embulk.config.ConfigException: Cannot execute a query: SELECT * FROM $PAGES
	at org.embulk.filter.calcite.CalciteFilterPlugin.executeQuery(CalciteFilterPlugin.java:166)
	at org.embulk.filter.calcite.CalciteFilterPlugin.access$200(CalciteFilterPlugin.java:50)
	at org.embulk.filter.calcite.CalciteFilterPlugin$FilterPageOutput.add(CalciteFilterPlugin.java:270)
	at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput$OutputWorker.call(LocalExecutorPlugin.java:394)
	at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput$OutputWorker.call(LocalExecutorPlugin.java:319)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.sql.SQLException: Error while executing SQL "SELECT * FROM $PAGES": null
	at org.apache.calcite.avatica.Helper.createException(Helper.java:56)
	at org.apache.calcite.avatica.Helper.createException(Helper.java:41)
	at org.apache.calcite.avatica.AvaticaStatement.executeInternal(AvaticaStatement.java:156)
	at org.apache.calcite.avatica.AvaticaStatement.executeQuery(AvaticaStatement.java:218)
	at org.embulk.filter.calcite.CalciteFilterPlugin.executeQuery(CalciteFilterPlugin.java:163)
	... 8 more
Caused by: java.lang.NullPointerException
	at org.embulk.filter.calcite.adapter.page.PageEnumerator.setPage(PageEnumerator.java:26)
	at org.embulk.filter.calcite.adapter.page.PageTable$1.enumerator(PageTable.java:63)
	at org.apache.calcite.linq4j.EnumerableDefaults$15$1.<init>(EnumerableDefaults.java:1896)
	at org.apache.calcite.linq4j.EnumerableDefaults$15.enumerator(EnumerableDefaults.java:1895)
	at org.apache.calcite.linq4j.EnumerableDefaults$15$1.<init>(EnumerableDefaults.java:1896)
	at org.apache.calcite.linq4j.EnumerableDefaults$15.enumerator(EnumerableDefaults.java:1895)
	at org.apache.calcite.interpreter.Interpreter.enumerator(Interpreter.java:98)
	at org.apache.calcite.linq4j.AbstractEnumerable.iterator(AbstractEnumerable.java:33)
	at org.apache.calcite.avatica.MetaImpl.createCursor(MetaImpl.java:89)
	at org.apache.calcite.avatica.AvaticaResultSet.execute(AvaticaResultSet.java:196)
	at org.apache.calcite.jdbc.CalciteResultSet.execute(CalciteResultSet.java:67)
	at org.apache.calcite.jdbc.CalciteResultSet.execute(CalciteResultSet.java:44)
	at org.apache.calcite.avatica.AvaticaConnection$1.execute(AvaticaConnection.java:607)
	at org.apache.calcite.jdbc.CalciteMetaImpl.prepareAndExecute(CalciteMetaImpl.java:599)
	at org.apache.calcite.avatica.AvaticaConnection.prepareAndExecuteInternal(AvaticaConnection.java:615)
	at org.apache.calcite.avatica.AvaticaStatement.executeInternal(AvaticaStatement.java:148)
	... 10 more
```