### PR TITLE
Use default_timezone option to configure JDBC connection timeZone param

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Data types by Apache Calcite: https://calcite.apache.org/docs/reference.html#dat
 ## Configuration
 
 - **query**: SQL to run (string)
-- **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
+- **default_timezone**: Set JDBC connect 'timeZone' param (string)
 
 ## Example
 
@@ -50,6 +50,14 @@ This enables adding new column and inserting the value combined 2 string column 
 filters:
   - type: calcite
     query: SELECT first_name || last_name AS name, * FROM $PAGES
+```
+
+Adds the new column by CURRENT_TIMESTAMP function.
+```yaml
+filters:
+  - type: calcite
+    query: SELECT CURRENT_TIMESTAMP, * FROM $PAGES
+    default_timezone: 'America/Los_Angeles'
 ```
 
 SQL language provided by Apache Calcite: https://calcite.apache.org/docs/reference.html

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Data types by Apache Calcite: https://calcite.apache.org/docs/reference.html#dat
 
 ## Configuration
 
-- **query**: SQL to run (string)
-- **default_timezone**: Set JDBC connect 'timeZone' param (string)
+- **query**: SQL to run (string, required)
+- **default_timezone**: Configure timezone that is used for JDBC connection properties and Calcite engine. This option is one of [JDBC connect parameters](https://calcite.apache.org/docs/adapter.html#jdbc-connect-string-parameters) provided by Apache Calcite. java.util.TimeZone's [AvailableIDs](http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getAvailableIDs) can be specified. (string, default: 'UTC')
 
 ## Example
 

--- a/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
@@ -84,6 +84,7 @@ public class CalciteFilterPlugin
     {
         PluginTask task = config.loadConfig(PluginTask.class);
         Properties props = System.getProperties(); // TODO should be configured as config option
+        setupProperties(task, props);
 
         // Set input schema in PageSchema
         PageSchema.schema = inputSchema;
@@ -107,6 +108,13 @@ public class CalciteFilterPlugin
         }
     }
 
+    private void setupProperties(PluginTask task, Properties props)
+    {
+        // @see https://calcite.apache.org/docs/adapter.html#jdbc-connect-string-parameters
+        props.setProperty("caseSensitive", "false"); // Relax case-sensitive
+        props.setProperty("timeZone", task.getDefaultTimeZone().getID());
+    }
+
     private PageConverter newPageConverter(PluginTask task, Schema inputSchema)
     {
         return new PageConverter(inputSchema, task.getDefaultTimeZone().toTimeZone());
@@ -116,9 +124,6 @@ public class CalciteFilterPlugin
     {
         String jdbcUrl = buildJdbcUrl();
         try {
-            // Relax case-sensitive
-            // @see https://calcite.apache.org/docs/adapter.html#jdbc-connect-string-parameters
-            props.setProperty("caseSensitive", "false");
             return new Driver().connect(jdbcUrl, props);
         }
         catch (SQLException e) {
@@ -240,6 +245,7 @@ public class CalciteFilterPlugin
         ColumnGetterFactory factory = newColumnGetterFactory(task, Optional.of(pageBuilder));
         List<ColumnGetter> getters = newColumnGetters(factory, task.getQuerySchema());
         Properties props = System.getProperties(); // TODO should be configured as config option
+        setupProperties(task, props);
         return new FilterPageOutput(outputSchema, task.getQuery(), pageBuilder, pageConverter, getters, props);
     }
 

--- a/src/main/java/org/embulk/filter/calcite/getter/FilterColumnGetterFactory.java
+++ b/src/main/java/org/embulk/filter/calcite/getter/FilterColumnGetterFactory.java
@@ -28,7 +28,7 @@ public class FilterColumnGetterFactory
         String valueType = option.getValueType();
         Type toType = getToType(option);
         if (valueType.equals("coalesce") && sqlTypeToValueType(column, column.getSqlType()).equals("timestamp")) {
-            return new UTCTimestampColumnGetter(to, toType, newTimestampFormatter(option, "%Y-%m-%d"));
+            return new UTCTimestampColumnGetter(to, toType, newTimestampFormatter(option, "%Y-%m-%d"), option.getTimeZone().or(defaultTimeZone));
         }
         else {
             return super.newColumnGetter(con, task, column, option);

--- a/src/main/java/org/embulk/filter/calcite/getter/FilterColumnGetterFactory.java
+++ b/src/main/java/org/embulk/filter/calcite/getter/FilterColumnGetterFactory.java
@@ -7,7 +7,6 @@ import org.embulk.input.jdbc.JdbcInputConnection;
 import org.embulk.input.jdbc.getter.ColumnGetter;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
@@ -28,18 +27,10 @@ public class FilterColumnGetterFactory
         String valueType = option.getValueType();
         Type toType = getToType(option);
         if (valueType.equals("coalesce") && sqlTypeToValueType(column, column.getSqlType()).equals("timestamp")) {
-            return new FilterTimestampColumnGetter(to, toType, newTimestampFormatter(option, "%Y-%m-%d"), option.getTimeZone().or(defaultTimeZone));
+            return new FilterTimestampColumnGetter(to, toType, option.getTimeZone().or(defaultTimeZone));
         }
         else {
             return super.newColumnGetter(con, task, column, option);
         }
-    }
-
-    private TimestampFormatter newTimestampFormatter(JdbcColumnOption option, String defaultTimestampFormat)
-    {
-        return new TimestampFormatter(
-                option.getJRuby(),
-                option.getTimestampFormat().isPresent() ? option.getTimestampFormat().get().getFormat() : defaultTimestampFormat,
-                option.getTimeZone().or(defaultTimeZone));
     }
 }

--- a/src/main/java/org/embulk/filter/calcite/getter/FilterColumnGetterFactory.java
+++ b/src/main/java/org/embulk/filter/calcite/getter/FilterColumnGetterFactory.java
@@ -28,7 +28,7 @@ public class FilterColumnGetterFactory
         String valueType = option.getValueType();
         Type toType = getToType(option);
         if (valueType.equals("coalesce") && sqlTypeToValueType(column, column.getSqlType()).equals("timestamp")) {
-            return new UTCTimestampColumnGetter(to, toType, newTimestampFormatter(option, "%Y-%m-%d"), option.getTimeZone().or(defaultTimeZone));
+            return new FilterTimestampColumnGetter(to, toType, newTimestampFormatter(option, "%Y-%m-%d"), option.getTimeZone().or(defaultTimeZone));
         }
         else {
             return super.newColumnGetter(con, task, column, option);

--- a/src/main/java/org/embulk/filter/calcite/getter/FilterTimestampColumnGetter.java
+++ b/src/main/java/org/embulk/filter/calcite/getter/FilterTimestampColumnGetter.java
@@ -14,12 +14,12 @@ import java.util.Calendar;
 import static java.util.Calendar.getInstance;
 import static java.util.TimeZone.getTimeZone;
 
-public class UTCTimestampColumnGetter
+public class FilterTimestampColumnGetter
         extends TimestampColumnGetter
 {
     private static final ThreadLocal<Calendar> calendar = new ThreadLocal<>();
 
-    public UTCTimestampColumnGetter(PageBuilder to, Type toType, TimestampFormatter timestampFormatter, DateTimeZone timeZone)
+    public FilterTimestampColumnGetter(PageBuilder to, Type toType, TimestampFormatter timestampFormatter, DateTimeZone timeZone)
     {
         super(to, toType, timestampFormatter);
         calendar.set(getInstance(getTimeZone(timeZone.getID()))); // set TLS here

--- a/src/main/java/org/embulk/filter/calcite/getter/FilterTimestampColumnGetter.java
+++ b/src/main/java/org/embulk/filter/calcite/getter/FilterTimestampColumnGetter.java
@@ -3,7 +3,6 @@ package org.embulk.filter.calcite.getter;
 import org.embulk.input.jdbc.getter.TimestampColumnGetter;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
@@ -19,9 +18,9 @@ public class FilterTimestampColumnGetter
 {
     private static final ThreadLocal<Calendar> calendar = new ThreadLocal<>();
 
-    public FilterTimestampColumnGetter(PageBuilder to, Type toType, TimestampFormatter timestampFormatter, DateTimeZone timeZone)
+    public FilterTimestampColumnGetter(PageBuilder to, Type toType, DateTimeZone timeZone)
     {
-        super(to, toType, timestampFormatter);
+        super(to, toType, null);
         calendar.set(getInstance(getTimeZone(timeZone.getID()))); // set TLS here
     }
 

--- a/src/main/java/org/embulk/filter/calcite/getter/UTCTimestampColumnGetter.java
+++ b/src/main/java/org/embulk/filter/calcite/getter/UTCTimestampColumnGetter.java
@@ -5,6 +5,7 @@ import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.type.Type;
+import org.joda.time.DateTimeZone;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -16,17 +17,12 @@ import static java.util.TimeZone.getTimeZone;
 public class UTCTimestampColumnGetter
         extends TimestampColumnGetter
 {
-    private static ThreadLocal<Calendar> calendar = new ThreadLocal<Calendar>() {
-        @Override
-        protected Calendar initialValue()
-        {
-            return getInstance(getTimeZone("UTC"));
-        }
-    };
+    private static final ThreadLocal<Calendar> calendar = new ThreadLocal<>();
 
-    public UTCTimestampColumnGetter(PageBuilder to, Type toType, TimestampFormatter timestampFormatter)
+    public UTCTimestampColumnGetter(PageBuilder to, Type toType, TimestampFormatter timestampFormatter, DateTimeZone timeZone)
     {
         super(to, toType, timestampFormatter);
+        calendar.set(getInstance(getTimeZone(timeZone.getID()))); // set TLS here
     }
 
     @Override

--- a/src/test/resources/org/embulk/filter/calcite/test/test_int_ops_filter.yml
+++ b/src/test/resources/org/embulk/filter/calcite/test/test_int_ops_filter.yml
@@ -1,2 +1,3 @@
 type: calcite
 query: 'SELECT id, id + 2, (id + 1) * id FROM $PAGES'
+default_timezone: 'UTC'

--- a/src/test/resources/org/embulk/filter/calcite/test/test_simple_filter.yml
+++ b/src/test/resources/org/embulk/filter/calcite/test/test_simple_filter.yml
@@ -1,2 +1,3 @@
 type: calcite
 query: 'SELECT * FROM $PAGES'
+default_timezone: 'UTC'

--- a/src/test/resources/org/embulk/filter/calcite/test/test_string_ops_filter.yml
+++ b/src/test/resources/org/embulk/filter/calcite/test/test_string_ops_filter.yml
@@ -1,2 +1,3 @@
 type: calcite
 query: 'SELECT purchase, purchase || purchase, CHAR_LENGTH(purchase), SUBSTRING(purchase FROM 2), SUBSTRING(purchase FROM 2 FOR 4) FROM $PAGES'
+default_timezone: 'UTC'

--- a/src/test/resources/org/embulk/filter/calcite/test/test_where_int_cond_filter.yml
+++ b/src/test/resources/org/embulk/filter/calcite/test/test_where_int_cond_filter.yml
@@ -1,2 +1,3 @@
 type: calcite
 query: 'SELECT * FROM $PAGES WHERE MOD(id, 2) = 0'
+default_timezone: 'UTC'

--- a/src/test/resources/org/embulk/filter/calcite/test/test_where_string_cond_filter.yml
+++ b/src/test/resources/org/embulk/filter/calcite/test/test_where_string_cond_filter.yml
@@ -1,2 +1,3 @@
 type: calcite
 query: SELECT * FROM $PAGES WHERE purchase LIKE '%0127'
+default_timezone: 'UTC'


### PR DESCRIPTION
The problem is that Apache Calcite's JDBC connections, by default, uses user-local timezone but, the plugin returns wrong values when Calcite's TIMESTAMP are converted with Embulk's Timestamp. Because the current plugin always converts the TIMESTAMP values by 'UTC'. Reported on https://github.com/muga/embulk-filter-calcite/pull/10.

This PR, in particular, https://github.com/muga/embulk-filter-calcite/pull/11/commits/a0503b51abd30f028db3beab57c1e7e4d3e0b9b9 commit fixes this issue. 