### PR TITLE
Add 'options' option to configure JDBC properties

### DIFF
--- a/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
@@ -40,6 +40,7 @@ import org.embulk.spi.Page;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
+import org.embulk.spi.unit.ToStringMap;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 
@@ -83,6 +84,9 @@ public class CalciteFilterPlugin
         // @see https://calcite.apache.org/docs/adapter.html#jdbc-connect-string-parameters
         props.setProperty("caseSensitive", "false"); // Relax case-sensitive
         props.setProperty("timeZone", task.getDefaultTimeZone().getID());
+
+        // overwrites props with 'options' option
+        props.putAll(task.getOptions());
     }
 
     private PageConverter newPageConverter(PluginTask task, Schema inputSchema) {
@@ -230,7 +234,10 @@ public class CalciteFilterPlugin
 
         // TODO support jdbc Url properties
         // TODO support column_options: option
-        // TODO support options: option
+
+        @Config("options")
+        @ConfigDefault("{}")
+        public ToStringMap getOptions();
 
         @ConfigInject
         public BufferAllocator getBufferAllocator();


### PR DESCRIPTION
This PR adds 'options' option to configure JDBC properties. The option is ported from [embulk-input-jdbc](https://github.com/embulk/embulk-input-jdbc/) plugin's 'options' option. Almost all of JDBC drivers provide JDBC properties to configure the behavior flexibly. Apache Calcite as well. It provides [JDBC properties](https://calcite.apache.org/docs/adapter.html#jdbc-connect-string-parameters). For example, the option could fix https://github.com/muga/embulk-filter-calcite/issues/12. 

It assumes https://github.com/muga/embulk-filter-calcite/pull/14.