### PR TITLE
Add warning to change default of case sensitive

### DIFF
--- a/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
@@ -82,11 +82,17 @@ public class CalciteFilterPlugin
 
     private void setupProperties(PluginTask task, Properties props) {
         // @see https://calcite.apache.org/docs/adapter.html#jdbc-connect-string-parameters
+        final ToStringMap options = task.getOptions();
+        if (!options.containsKey("caseSensitive")) {
+            log.warn("JDBC parameter 'caseSensitive' is implicitly set to false as default in");
+            log.warn("embulk-filter-calcite 0.1 but, it's scheduled to change default with true");
+            log.warn("in 0.2. Please use 'options' option to set 'caseSensitive' to false.");
+        }
         props.setProperty("caseSensitive", "false"); // Relax case-sensitive
         props.setProperty("timeZone", task.getDefaultTimeZone().getID());
 
         // overwrites props with 'options' option
-        props.putAll(task.getOptions());
+        props.putAll(options);
     }
 
     private PageConverter newPageConverter(PluginTask task, Schema inputSchema) {


### PR DESCRIPTION
### Background

Since the plugin will support 'options' option on #17, users can specify JDBC parameters by themselves. The version 0.1 of this plugin configures 'caseSensitive=false' but, the setting will be unnecessary any more.

### Suggestion

To remove 'caseSensitive=false' setting from the plugin in version 0.2 (https://github.com/muga/embulk-filter-calcite/issues/19), this PR first adds warning messages. It allows users to know what they should do. 

This PR assumes #14 and #17. 