### PR TITLE
Deduplicate redundant logging to fix #24

### DIFF
--- a/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
@@ -55,7 +55,7 @@ public class CalciteFilterPlugin implements FilterPlugin {
     public void transaction(ConfigSource config, Schema inputSchema, FilterPlugin.Control control) {
         PluginTask task = config.loadConfig(PluginTask.class);
         Properties props = System.getProperties(); // TODO should be configured as config option
-        setupProperties(task, props);
+        setupPropertiesFromTransaction(task, props);
 
         // Set input schema in PageSchema
         PageSchema.schema = inputSchema;
@@ -81,14 +81,19 @@ public class CalciteFilterPlugin implements FilterPlugin {
         }
     }
 
-    private void setupProperties(PluginTask task, Properties props) {
-        // @see https://calcite.apache.org/docs/adapter.html#jdbc-connect-string-parameters
+    private void setupPropertiesFromTransaction(PluginTask task, Properties props) {
         final ToStringMap options = task.getOptions();
         if (!options.containsKey("caseSensitive")) {
             log.warn("JDBC parameter 'caseSensitive' is implicitly set to false as default in");
             log.warn("embulk-filter-calcite 0.1 but, it's scheduled to change default with true");
             log.warn("in 0.2. Please use 'options' option to set 'caseSensitive' to false.");
         }
+        setupProperties(task, props);
+    }
+
+    private void setupProperties(PluginTask task, Properties props) {
+        // @see https://calcite.apache.org/docs/adapter.html#jdbc-connect-string-parameters
+        final ToStringMap options = task.getOptions();
         props.setProperty("caseSensitive", "false"); // Relax case-sensitive
         props.setProperty("timeZone", task.getDefaultTimeZone().getID());
 


### PR DESCRIPTION
This PR deduplicates the following redundant logging. The messages are shown in console every `FilterPageOutput` objects creation. They are redundant.

```
2017-05-17 05:28:35.871 -0700 [WARN] (0001:transaction): JDBC parameter 'caseSensitive' is implicitly set to false as default in
2017-05-17 05:28:35.872 -0700 [WARN] (0001:transaction): embulk-filter-calcite 0.1 but, it's scheduled to change default with true
2017-05-17 05:28:35.872 -0700 [WARN] (0001:transaction): in 0.2. Please use 'options' option to set 'caseSensitive' to false.
```