### PR TITLE
Not set case sensitive implicitly

### DIFF
--- a/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
@@ -84,18 +84,12 @@ public class CalciteFilterPlugin implements FilterPlugin {
 
     private void setupPropertiesFromTransaction(PluginTask task, Properties props) {
         final ToStringMap options = task.getOptions();
-        if (!options.containsKey("caseSensitive")) {
-            log.warn("JDBC parameter 'caseSensitive' is implicitly set to false as default in");
-            log.warn("embulk-filter-calcite 0.1 but, it's scheduled to change default with true");
-            log.warn("in 0.2. Please use 'options' option to set 'caseSensitive' to false.");
-        }
         setupProperties(task, props);
     }
 
     private void setupProperties(PluginTask task, Properties props) {
         // @see https://calcite.apache.org/docs/adapter.html#jdbc-connect-string-parameters
         final ToStringMap options = task.getOptions();
-        props.setProperty("caseSensitive", "false"); // Relax case-sensitive
         props.setProperty("timeZone", task.getDefaultTimeZone().getID());
 
         // overwrites props with 'options' option

--- a/src/test/resources/org/embulk/filter/calcite/test/test_int_ops_filter.yml
+++ b/src/test/resources/org/embulk/filter/calcite/test/test_int_ops_filter.yml
@@ -1,3 +1,5 @@
 type: calcite
 query: 'SELECT id, id + 2, (id + 1) * id FROM $PAGES'
 default_timezone: 'UTC'
+options:
+  caseSensitive: false

--- a/src/test/resources/org/embulk/filter/calcite/test/test_string_ops_filter.yml
+++ b/src/test/resources/org/embulk/filter/calcite/test/test_string_ops_filter.yml
@@ -1,3 +1,5 @@
 type: calcite
 query: 'SELECT purchase, purchase || purchase, CHAR_LENGTH(purchase), SUBSTRING(purchase FROM 2), SUBSTRING(purchase FROM 2 FOR 4) FROM $PAGES'
 default_timezone: 'UTC'
+options:
+  caseSensitive: false

--- a/src/test/resources/org/embulk/filter/calcite/test/test_where_int_cond_filter.yml
+++ b/src/test/resources/org/embulk/filter/calcite/test/test_where_int_cond_filter.yml
@@ -1,3 +1,5 @@
 type: calcite
 query: 'SELECT * FROM $PAGES WHERE MOD(id, 2) = 0'
 default_timezone: 'UTC'
+options:
+  caseSensitive: false

--- a/src/test/resources/org/embulk/filter/calcite/test/test_where_string_cond_filter.yml
+++ b/src/test/resources/org/embulk/filter/calcite/test/test_where_string_cond_filter.yml
@@ -1,3 +1,5 @@
 type: calcite
 query: SELECT * FROM $PAGES WHERE purchase LIKE '%0127'
 default_timezone: 'UTC'
+options:
+  caseSensitive: false


### PR DESCRIPTION
This PR removes implicit setting JDBC connection property 'caseSensitive' to false. Since this change breaks backward compatible of the behavior, we will increment major version of the plugin as next version.

ref: https://github.com/muga/embulk-filter-calcite/issues/19