### PR TITLE
Stop using org.embulk.spi.unit.ToStringMap

### DIFF
--- a/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
@@ -39,7 +39,6 @@ import org.embulk.spi.Page;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
-import org.embulk.spi.unit.ToStringMap;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,13 +78,12 @@ public class CalciteFilterPlugin implements FilterPlugin {
     }
 
     private void setupPropertiesFromTransaction(PluginTask task, Properties props) {
-        final ToStringMap options = task.getOptions();
         setupProperties(task, props);
     }
 
     private void setupProperties(PluginTask task, Properties props) {
         // @see https://calcite.apache.org/docs/adapter.html#jdbc-connect-string-parameters
-        final ToStringMap options = task.getOptions();
+        final Map<String, String> options = task.getOptions();
         props.setProperty("timeZone", task.getDefaultTimeZone().getID());
 
         // overwrites props with 'options' option
@@ -255,7 +253,7 @@ public class CalciteFilterPlugin implements FilterPlugin {
 
         @Config("options")
         @ConfigDefault("{}")
-        public ToStringMap getOptions();
+        public Map<String, String> getOptions();
     }
 
     private class FilterPageOutput


### PR DESCRIPTION
The Embulk core is going to deprecate `org.embulk.spi.unit.ToStringMap`. Mapping into `Map<String, String>` has almost the same effect, only except for handling `null` as tested in: https://github.com/embulk/embulk/pull/1267

But, in this use-case of `ToStringMap` in embulk-filter-calcite, we can ignore `null`. Then just replacing to `Map<String, String>` here.