### PR TITLE
Use constructors of PageBuilder and PageReader if Embulk is old

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "org.embulk"
-version = "0.5.0-SNAPSHOT"
+version = "0.5.1-SNAPSHOT"
 description = "Translate schema and column values by SQL-like query provided by Apache Calcite."
 
 sourceCompatibility = 1.8
@@ -32,7 +32,7 @@ dependencies {
     compileOnly "org.embulk:embulk-api:0.10.31"
     compileOnly "org.embulk:embulk-spi:0.10.31"
 
-    compile("org.embulk:embulk-input-jdbc:0.12.1") {
+    compile("org.embulk:embulk-input-jdbc:0.12.2") {
         // They conflict with embulk-core. They are once excluded here,
         // and added explicitly with versions exactly the same with embulk-core:0.10.31.
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -24,7 +24,7 @@ org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
 org.codehaus.janino:commons-compiler:2.7.6
 org.codehaus.janino:janino:2.7.6
-org.embulk:embulk-input-jdbc:0.12.1
+org.embulk:embulk-input-jdbc:0.12.2
 org.embulk:embulk-util-config:0.3.0
 org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2

--- a/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/calcite/CalciteFilterPlugin.java
@@ -231,7 +231,7 @@ public class CalciteFilterPlugin implements FilterPlugin {
         // Set input schema in PageSchema for various types of executor plugins
         PageSchema.schema = inputSchema;
 
-        final PageBuilder pageBuilder = Exec.getPageBuilder(Exec.getBufferAllocator(), outputSchema, output);
+        final PageBuilder pageBuilder = getPageBuilder(Exec.getBufferAllocator(), outputSchema, output);
         PageConverter pageConverter = newPageConverter(task, inputSchema);
         ColumnGetterFactory factory = newColumnGetterFactory(task, Optional.of(pageBuilder));
         List<ColumnGetter> getters = newColumnGetters(factory, task.getQuerySchema());
@@ -329,4 +329,24 @@ public class CalciteFilterPlugin implements FilterPlugin {
             }
         }
     }
+
+    @SuppressWarnings("deprecation")
+    private static PageBuilder getPageBuilder(final BufferAllocator bufferAllocator, final Schema schema, final PageOutput output) {
+        if (HAS_EXEC_GET_PAGE_BUILDER) {
+            return Exec.getPageBuilder(bufferAllocator, schema, output);
+        } else {
+            return new PageBuilder(bufferAllocator, schema, output);
+        }
+    }
+
+    private static boolean hasExecGetPageBuilder() {
+        try {
+            Exec.class.getMethod("getPageBuilder", BufferAllocator.class, Schema.class, PageOutput.class);
+        } catch (final NoSuchMethodException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static final boolean HAS_EXEC_GET_PAGE_BUILDER = hasExecGetPageBuilder();
 }

--- a/src/main/java/org/embulk/filter/calcite/adapter/page/PageEnumerator.java
+++ b/src/main/java/org/embulk/filter/calcite/adapter/page/PageEnumerator.java
@@ -21,7 +21,7 @@ public class PageEnumerator implements Enumerator<Object[]> {
      */
     public PageEnumerator(Schema schema, PageConverter pageConverter) {
         this.schema = schema;
-        this.pageReader = Exec.getPageReader(schema);
+        this.pageReader = getPageReader(schema);
         this.pageConverter = pageConverter;
     }
 
@@ -53,4 +53,24 @@ public class PageEnumerator implements Enumerator<Object[]> {
             pageReader.close();
         }
     }
+
+    @SuppressWarnings("deprecation")
+    private static PageReader getPageReader(final Schema schema) {
+        if (HAS_EXEC_GET_PAGE_READER) {
+            return Exec.getPageReader(schema);
+        } else {
+            return new PageReader(schema);
+        }
+    }
+
+    private static boolean hasExecGetPageReader() {
+        try {
+            Exec.class.getMethod("getPageReader", Schema.class);
+        } catch (final NoSuchMethodException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static final boolean HAS_EXEC_GET_PAGE_READER = hasExecGetPageReader();
 }


### PR DESCRIPTION
`Exec.getPageBuilder` and `Exec.getPageReader` are only in Embulk v0.10.17+, then `embulk-filter-calcite:0.5.0` didn't work with Embulk v0.9.23.

Because this is an open-sourced plugin for everyone, fixing it to work with Embulk v0.9.23.

----

At the same time, updating the dependent `embulk-input-jdbc` to `0.12.2` released with https://github.com/embulk/embulk-input-jdbc/pull/218